### PR TITLE
Return current value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+brightnessctl

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Options:
   -c, --class=CLASS		specify device class.
 
 Operations:
+  i, info			get device info.
   g, get			get current brightness of the device.
   m, max			get maximum brightness of the device.
   s, set VALUE			set brightness of the device.

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -210,6 +210,7 @@ int apply_operation(struct device *dev, unsigned int operation, struct value *va
 				fprintf(stdout, "Updated device '%s':\n", dev->id);
 			return print_device(dev);
 		}
+	/* FALLTHRU */
 	fail:
 	default:
 		return 0;

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -59,7 +59,7 @@ struct value {
 	unsigned int sign : 1;
 };
 
-enum operation { GET, MAX, SET };
+enum operation { INFO, GET, MAX, SET };
 
 struct params {
 	char *class;
@@ -155,15 +155,17 @@ int main(int argc, char **argv) {
 	if (!dev_name)
 		dev_name = devs[0]->id;
 	if (argc == 0)
-		p.operation = GET;
+		p.operation = INFO;
 	else switch (argv[0][0]) {
 	case 'm':
 		p.operation = MAX; break;
 	case 's':
 		p.operation = SET; break;
-	default:
 	case 'g':
 		p.operation = GET; break;
+	default:
+	case 'i':
+		p.operation = INFO; break;
 	}
 	argc--;
 	argv++;
@@ -195,8 +197,11 @@ int main(int argc, char **argv) {
 
 int apply_operation(struct device *dev, unsigned int operation, struct value *val) {
 	switch (operation) {
-	case GET:
+	case INFO:
 		return print_device(dev);
+	case GET:
+		fprintf(stdout, "%u\n", dev->curr_brightness);
+		return 0;
 	case MAX:
 		fprintf(stdout, "%u\n", dev->max_brightness);
 		return 0;
@@ -545,6 +550,7 @@ Options:\n\
   -c, --class=CLASS\t\tspecify device class.\n\
 \n\
 Operations:\n\
+  i, info\t\t\tget device info.\n\
   g, get\t\t\tget current brightness of the device.\n\
   m, max\t\t\tget maximum brightness of the device.\n\
   s, set VALUE\t\t\tset brightness of the device.\n\

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -245,7 +245,7 @@ int parse_value(struct value *val, char *str) {
 		val->d_type = DELTA;
 		break;
 	case '%':
-		val->v_type = RELATIVE;	
+		val->v_type = RELATIVE;
 		break;
 	}
 	return 0;
@@ -269,7 +269,7 @@ int list_devices(struct device **devs) {
 }
 
 int print_device(struct device *dev) {
-	char *format = p.mach ? "%s,%s,%d,%d%%,%d\n": 
+	char *format = p.mach ? "%s,%s,%d,%d%%,%d\n":
 		"Device '%s' of class '%s':\n\tCurrent brightness: %d (%d%%)\n\tMax brightness: %d\n\n";
 	fprintf(stdout, format,
 		dev->id, dev->class,


### PR DESCRIPTION
Change output when explicitly calling ''get" command to only return the value, similar to "max". This makes it possible to use this in scripts without additional output parsing.

If called with no explicit command, it still returns the same output as before.