### PR TITLE
Fix file mode for non-suid binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,8 @@ MODE = ${MODE_${INSTALL_UDEV_RULES}}
 all: brightnessctl
 
 install: brightnessctl ${INSTALL_UDEV_${INSTALL_UDEV_RULES}}
-	install -d ${DESTDIR}${PREFIX}/bin
-	install -m ${MODE} brightnessctl ${DESTDIR}${PREFIX}/bin/
+	install -d ${BINDIR}
+	install -m ${MODE} brightnessctl ${BINDIR}/
 
 install_udev_rules:
 	install -d ${DESTDIR}${UDEVDIR}

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ INSTALL_UDEV_1 = install_udev_rules
 UDEVDIR ?= /lib/udev/rules.d
 
 MODE_0 = 4711
-MODE_1 = 0644
+MODE_1 = 0755
 MODE = ${MODE_${INSTALL_UDEV_RULES}}
 
 all: brightnessctl


### PR DESCRIPTION
Use the file mode 0711 (executable but not suid) when installing the binary with `INSTALL_UDEV_RULES=1`.

Use `BINDIR` in the `Makefile` `install` rule.