### PR TITLE
Added flag to dissallow setting brightness to zero when using delta values

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Options:
   -q, --quiet			suppress output.
   -p, --pretend			do not perform write operations.
   -m, --machine-readable	produce machine-readable output.
-  -n, --never-zero		disallow setting to 0 when using delta values.
+  -n, --min-value		set minimum brightness, defaults to 1.
   -s, --save			save previous state in a temporary file.
   -r, --restore			restore previous saved state.
   -h, --help			print this help.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Options:
   -q, --quiet			suppress output.
   -p, --pretend			do not perform write operations.
   -m, --machine-readable	produce machine-readable output.
+  -n, --never-zero		disallow setting to 0 when using delta values.
   -s, --save			save previous state in a temporary file.
   -r, --restore			restore previous saved state.
   -h, --help			print this help.

--- a/brightnessctl.1
+++ b/brightnessctl.1
@@ -43,9 +43,9 @@ Produce machine\-readable output.
 .RE
 
 .sp
-\fB\-n, \-\-never\-zero\fP
+\fB\-n, \-\-min\-value\fP=\fIVALUE\fP
 .RS 4
-Disallow setting brightness to zero when using delta values.
+Set minimum brightness when using delta values, defaults to 1.
 .RE
 
 .sp

--- a/brightnessctl.1
+++ b/brightnessctl.1
@@ -43,6 +43,12 @@ Produce machine\-readable output.
 .RE
 
 .sp
+\fB\-n, \-\-never\-zero\fP
+.RS 4
+Disallow setting brightness to zero when using delta values.
+.RE
+
+.sp
 \fB\-s, \-\-save\fP
 .RS 4
 Save state in a temporary file.

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -71,6 +71,7 @@ struct params {
 	unsigned int list : 1;
 	unsigned int pretend : 1;
 	unsigned int mach : 1;
+	unsigned int never : 1;
 	unsigned int operation : 2;
 	unsigned int save : 1;
 	unsigned int restore : 1;
@@ -84,6 +85,7 @@ static const struct option options[] = {
 	{"help", no_argument, NULL, 'h'},
 	{"list", no_argument, NULL, 'l'},
 	{"machine-readable", no_argument, NULL, 'm'},
+	{"never-zero", no_argument, NULL, 'n'},
 	{"quiet", no_argument, NULL, 'q'},
 	{"pretend", no_argument, NULL, 'p'},
 	{"restore", no_argument, NULL, 'r'},
@@ -103,7 +105,7 @@ int main(int argc, char **argv) {
 	if (strcmp(name.sysname, "Linux"))
 		fail("This program only supports Linux.\n");
 	while (1) {
-		if ((c = getopt_long(argc, argv, "lqpmsrhVc:d:", options, NULL)) < 0)
+		if ((c = getopt_long(argc, argv, "lqpmnsrhVc:d:", options, NULL)) < 0)
 			break;
 		switch (c) {
 		case 'l':
@@ -123,6 +125,9 @@ int main(int argc, char **argv) {
 			break;
 		case 'm':
 			p.mach = 1;
+			break;
+		case 'n':
+			p.never = 1;
 			break;
 		case 'h':
 			usage();
@@ -303,6 +308,8 @@ void apply_value(struct device *d, struct value *val) {
 	new = d->curr_brightness + mod;
 	if (new < 0)
 		new = 0;
+	if (p.never && new == 0)
+		new = 1;
 	if (new > d->max_brightness)
 		new = d->max_brightness;
 apply:
@@ -550,6 +557,7 @@ Options:\n\
   -q, --quiet\t\t\tsuppress output.\n\
   -p, --pretend\t\t\tdo not perform write operations.\n\
   -m, --machine-readable\tproduce machine-readable output.\n\
+  -n, --never-zero\t\tdisallow setting to 0 when using delta values.\n\
   -s, --save\t\t\tsave previous state in a temporary file.\n\
   -r, --restore\t\t\trestore previous saved state.\n\
   -h, --help\t\t\tprint this help.\n\


### PR DESCRIPTION
I've been using brightnessctl with hotkeys on my laptop and was frustrated with how if I hit my brightness down key too many times down it would turn my display off. This setting allows me turn brightness as low as it will go without turning the display completely off. 

I'm kinda new to contributing to open source so let me know if there's anything I need to change or if you aren't interested in these changes.