### PR TITLE
fix wrong bool bug

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -414,7 +414,7 @@ int read_class(struct device **devs, char *class) {
 		if (!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, ".."))
 			continue;
 		dev = malloc(sizeof(struct device));
-		if (!read_device(dev, class, ent->d_name)) {
+		if (read_device(dev, class, ent->d_name)) {
 			free(dev);
 			continue;
 		}


### PR DESCRIPTION
`read_device`  returns 0 on success and >0 on failure.
`read_class` seems to be expecting the reverse, as it discards the returned device if `read_device` returns 0 (success).
This  commit removes the `!`, that's it.