### PR TITLE
Fixes return code when set in quiet mode

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -236,8 +236,8 @@ int apply_operation(struct device *dev, enum operation operation, struct value *
 			if (!p.mach)
 				fprintf(stdout, "Updated device '%s':\n", dev->id);
 			print_device(dev);
-			return 0;
 		}
+		return 0;
 	/* FALLTHRU */
 	fail:
 	default:


### PR DESCRIPTION
Return code when running "brightnessctl set 100%" is 0, as expected.
When running "brightnessctl -q set 100%" the return code is 1, even if the command succeeded.

Before changes:
```
% brightnessctl set 100% && echo Done
Updated device 'intel_backlight':
Device 'intel_backlight' of class 'backlight':
        Current brightness: 7500 (100%)
        Max brightness: 7500

Done
% brightnessctl -q set 100% && echo Done
```

Now:
```
% ./brightnessctl -q set 100% && echo Done
Done
```