### PR TITLE
Support the new `SetBrightness` logind API.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ INSTALL_UDEV_RULES = 1
 INSTALL_UDEV_1 = install_udev_rules
 UDEVDIR ?= /lib/udev/rules.d
 
+ifdef ENABLE_SYSTEMD
+	CFLAGS += ${shell pkg-config --cflags libsystemd}
+	LDLIBS += ${shell pkg-config --libs libsystemd}
+	CPPFLAGS += -DENABLE_SYSTEMD
+endif
+
 MODE_0 = 4711
 MODE_1 = 0755
 MODE = ${MODE_${INSTALL_UDEV_RULES}}

--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ One can build and install the program using `make install`. Consult the Makefile
 
 ## Permissions
 
-Modifying brightness requires write permissions for device files. `brightnessctl` accomplishes this (without using `sudo`/`su`/etc.) by either of the following means:
+Modifying brightness requires write permissions for device files or systemd support. `brightnessctl` accomplishes this (without using `sudo`/`su`/etc.) by either of the following means:
 
 1) installing relevant udev rules to add permissions to backlight class devices for users in `video` and leds for users in `input`. (done by default)
 
 2) installing `brightnessctl` as a suid binary.
 
+3) using the `systemd-logind` API.
+
 The behavior is controlled by the `INSTALL_UDEV_RULES` flag (setting it to `1` installs the udev rules, it is the default value).
+
+The systemd support (since v243) is controlled by the `ENABLE_SYSTEMD` flag (in that case it is recommended to set `INSTALL_UDEV_RULES` to 0).
 
 ## Usage
 ```


### PR DESCRIPTION
This API from `org.freedesktop.login1.Session` allows an unprivileged
user with an active session to change its own backlight.

It introduces a configurable dependency to `libsystemd`. When enabled it will be used only if the user doesn't have write permission to the device.

Systemd >= v243 is needed.

Closes #23 