### PR TITLE
Use non-suid permissions when logind is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,16 @@ INSTALL_UDEV_RULES = 1
 INSTALL_UDEV_1 = install_udev_rules
 UDEVDIR ?= /lib/udev/rules.d
 
+MODE_0 = 4711
+MODE_1 = 0755
+MODE = ${MODE_${INSTALL_UDEV_RULES}}
+
 ifdef ENABLE_SYSTEMD
 	CFLAGS += ${shell pkg-config --cflags libsystemd}
 	LDLIBS += ${shell pkg-config --libs libsystemd}
 	CPPFLAGS += -DENABLE_SYSTEMD
+	MODE = 0755
 endif
-
-MODE_0 = 4711
-MODE_1 = 0755
-MODE = ${MODE_${INSTALL_UDEV_RULES}}
 
 all: brightnessctl brightnessctl.1
 


### PR DESCRIPTION
When `systemd-logind` and its D-Bus API is used to actual change the brightness of devices the binary does not have to be `suid`, which is desired for security reasons. Therefore default the `MODE` to `0755` on `ENABLE_SYSTEMD`.
