### PR TITLE
Fix the build, due to missing prototype and `apply_value`

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -366,6 +366,11 @@ apply:
 	return new;
 }
 
+void apply_value(struct device *d, struct value *val) {
+	int new = calc_value(d, val);
+	d->curr_brightness = new;
+}
+
 #ifdef ENABLE_SYSTEMD
 
 bool logind_set_brightness(struct device *d) {

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -48,6 +48,7 @@ static struct device *find_device(struct device **, char *);
 static bool save_device_data(struct device *);
 static bool restore_device_data(struct device *);
 static bool ensure_dir(char *);
+static bool ensure_dev_dir(struct device *dev);
 #define ensure_run_dir() ensure_dir(run_dir)
 
 #ifdef ENABLE_SYSTEMD


### PR DESCRIPTION
The build is currently [broken](https://travis-ci.org/gicmo/brightnessctl/jobs/642009635) due to:

```
brightnessctl.c: In function ‘save_device_data’:
brightnessctl.c:516:7: warning: implicit declaration of function ‘ensure_dev_dir’; did you mean ‘ensure_run_dir’? [-Wimplicit-function-declaration]
  if (!ensure_dev_dir(dev))
       ^~~~~~~~~~~~~~
       ensure_run_dir
brightnessctl.c: At top level:
brightnessctl.c:582:6: error: conflicting types for ‘ensure_dev_dir’
 bool ensure_dev_dir(struct device *dev) {
      ^~~~~~~~~~~~~~
brightnessctl.c:516:7: note: previous implicit declaration of ‘ensure_dev_dir’ was here
  if (!ensure_dev_dir(dev))
       ^~~~~~~~~~~~~~
brightnessctl.c:38:13: warning: ‘apply_value’ used but never defined
 static void apply_value(struct device *, struct value *);
```
The last warning leads to a linker error later, because `apply_value` was renamed in commit 7b607b3.