### PR TITLE
Add CI via Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: c
+
+dist: bionic
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  - ENABLE_SYSTEMD=0
+  - ENABLE_SYSTEMD=1
+
+addons:
+  apt:
+    packages:
+      - libsystemd-dev
+
+script:
+  - make


### PR DESCRIPTION
Add continuous integration via Travis CI https://travis-ci.org
It still needs to be enabled on travis itself. I have done it for my fork and [tested it](https://travis-ci.org/gicmo/brightnessctl/builds/642009634). NB the build is currently broken (see PR #42)