### PR TITLE
Build fixups and systemd install tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ ifdef ENABLE_SYSTEMD
 	LDLIBS += ${shell pkg-config --libs libsystemd}
 	CPPFLAGS += -DENABLE_SYSTEMD
 	MODE = 0755
+	INSTALL_UDEV_RULES = 0
 endif
 
 all: brightnessctl brightnessctl.1

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -35,7 +35,8 @@ static char *_cat_with(char, ...);
 static char *dir_child(char *, char*);
 static char *device_path(struct device *);
 static char *class_path(char *);
-static void apply_value(struct device *, struct value *);
+static unsigned int calc_value(struct device *d, struct value *val);
+static void apply_value(struct device *, unsigned int);
 static int apply_operation(struct device *, enum operation, struct value *);
 static bool parse_value(struct value *, char *);
 static bool do_write_device(struct device *);
@@ -251,7 +252,7 @@ int apply_operation(struct device *dev, enum operation operation, struct value *
 		fprintf(stdout, "%u\n", dev->max_brightness);
 		return 0;
 	case SET:
-		apply_value(dev, val);
+		apply_value(dev, calc_value(dev, val));
 		if (!p.pretend)
 			if (!write_device(dev))
 				goto fail;
@@ -338,6 +339,10 @@ void print_device(struct device *dev) {
 		dev->curr_brightness,
 		(int) val_to_percent(dev->curr_brightness, dev, true),
 		dev->max_brightness);
+}
+
+void apply_value(struct device *d, unsigned int val) {
+	d->curr_brightness = val;
 }
 
 unsigned int calc_value(struct device *d, struct value *val) {

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -50,6 +50,7 @@ static bool save_device_data(struct device *);
 static bool restore_device_data(struct device *);
 static bool ensure_dir(char *);
 #define ensure_run_dir() ensure_dir(run_dir)
+bool ensure_dev_dir(struct device *dev);
 
 #ifdef ENABLE_SYSTEMD
 static bool logind_set_brightness(struct device *);


### PR DESCRIPTION
On `master` there are a couple of compilation failures for me locally. The first two commits in this PR fix those up.

The final commit tweaks the install so that when systemd support is enabled, we skip adding udev rules (since they shouldn't be necessary any longer).

Tested locally on Fedora 31 w/ sway and all seems to be in order.

I've pasted the build errors I get on current `master` below (I think: the link error is introduced in 7b607b3 when `apply_value` became `calc_value`, and 9eee34e just missed a declaration for `ensure_dev_dir`):

```
j@.. ~/s/brightnessctl> make
cc -std=c99 -g -Wall -Wextra -DVERSION=\"0.4\" -D_POSIX_C_SOURCE=200809L    brightnessctl.c  -lm -o brightnessctl
brightnessctl.c: In function ‘save_device_data’:
brightnessctl.c:516:7: warning: implicit declaration of function ‘ensure_dev_dir’; did you mean ‘ensure_run_dir’? [-Wimplicit-function-declaration]
  516 |  if (!ensure_dev_dir(dev))
      |       ^~~~~~~~~~~~~~
      |       ensure_run_dir
brightnessctl.c: At top level:
brightnessctl.c:582:6: error: conflicting types for ‘ensure_dev_dir’
  582 | bool ensure_dev_dir(struct device *dev) {
      |      ^~~~~~~~~~~~~~
brightnessctl.c:516:7: note: previous implicit declaration of ‘ensure_dev_dir’ was here
  516 |  if (!ensure_dev_dir(dev))
      |       ^~~~~~~~~~~~~~
brightnessctl.c:38:13: warning: ‘apply_value’ used but never defined
   38 | static void apply_value(struct device *, struct value *);
      |             ^~~~~~~~~~~
make: *** [<builtin>: brightnessctl] Error 1
```

