### PR TITLE
Support fractional values

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Operations:
 
 Valid values:
   specific value		Example: 500
-  percentage value		Example: 50%
+  percentage value		Example: 50.5%
   specific delta		Example: 50- or +10
   percentage delta		Example: 50%- or +10%
  ```

--- a/brightnessctl.1
+++ b/brightnessctl.1
@@ -124,9 +124,9 @@ as a value or a delta from the current value. For example:
 Sets brightness to 500.
 .P
 .RE
-\fBbrightnessctl set 50%\fR
+\fBbrightnessctl set 50.75%\fR
 .RS "4"
-Sets brightness to 50% of the maximum.
+Sets brightness to 50.75% of the maximum.
 .P
 .RE
 \fBbrightnessctl set 50-\fR


### PR DESCRIPTION
Treat values passed on the command line as `float`s instead of `long`s. This allows you to specify fractional percentages (and fractional absolute values, too, though they’ll just be rounded down, so they’re not particularly useful).

Report the display brightness as a percentage with two decimal places rather than zero. To ensure backward compatibility in machine-readable mode, report the high-precision percentage in a new field rather than replacing the existing field. This does cause some redundancy in the output, but that’s better than breaking scripts that assume the 4th field is an integer followed by “%”.

Closes: https://github.com/Hummer12007/brightnessctl/issues/50