### PR TITLE
Don't log info if quiet is set when restoring

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -73,7 +73,7 @@ struct value {
 	enum sign sign;
 };
 
-enum operation { INFO, GET, MAX, SET };
+enum operation { INFO, GET, MAX, SET, RESTORE };
 
 struct params {
 	char *class;
@@ -241,7 +241,7 @@ int main(int argc, char **argv) {
 			fprintf(stderr, "Could not save data for device '%s'.\n", dev->id);
 	if (p.restore) {
 		if (restore_device_data(dev))
-			write_device(dev);
+			p.operation = RESTORE;
 	}
 	return apply_operation(dev, p.operation, &p.val);
 }
@@ -259,6 +259,8 @@ int apply_operation(struct device *dev, enum operation operation, struct value *
 		return 0;
 	case SET:
 		dev->curr_brightness = calc_value(dev, val);
+	/* FALLTHRU */
+	case RESTORE:
 		if (!p.pretend)
 			if (!write_device(dev))
 				goto fail;


### PR DESCRIPTION
Heya!

Great tool :) 

I found this out yesterday when restoring with the quiet flag it seems to always log info afterwards, which seems like the wrong behaviour to me. It also seems like it won't obey the pretend flag.

There were a few different variations of fixing this I thought of but I felt like this was the most concise and allowed you to restore quietly and allowed you to restore and pretend restore. In particular I feel like restore is a special case of set, not a separate thing entirely.

I'm happy to change this to a different approach if you prefer.