### PR TITLE
Deal with LEDs or backlight peripherals w/o brightness control

### DIFF
--- a/90-brightnessctl.rules
+++ b/90-brightnessctl.rules
@@ -1,4 +1,2 @@
-ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chgrp video /sys/class/backlight/%k/brightness"
-ACTION=="add", SUBSYSTEM=="backlight", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"
-ACTION=="add", SUBSYSTEM=="leds", RUN+="/bin/chgrp input /sys/class/leds/%k/brightness"
-ACTION=="add", SUBSYSTEM=="leds", RUN+="/bin/chmod g+w /sys/class/leds/%k/brightness"
+ACTION=="add", SUBSYSTEM=="backlight", RUN+="bright-helper video g+w /sys/class/backlight/%k/brightness"
+ACTION=="add", SUBSYSTEM=="leds",      RUN+="bright-helper input g+w /sys/class/leds/%k/brightness"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INSTALL_UDEV_RULES = 1
 
 INSTALL_UDEV_1 = install_udev_rules
 UDEVDIR ?= /lib/udev/rules.d
+UDEV_HELPER_DIR ?= /lib/udev/
 
 MODE_0 = 4711
 MODE_1 = 0755
@@ -30,11 +31,15 @@ install: all ${INSTALL_UDEV_${INSTALL_UDEV_RULES}}
 	install -m ${MODE} brightnessctl   ${BINDIR}/
 	install -m 0644    brightnessctl.1 ${MANDIR}/man1
 
-install_udev_rules:
+install_udev_rules: install_udev_helper
 	install -d ${DESTDIR}${UDEVDIR}
 	install -m 0644 90-brightnessctl.rules ${DESTDIR}${UDEVDIR}
+
+install_udev_helper:
+	install -d ${DESTDIR}${UDEV_HELPER_DIR}
+	install -m 0755 bright-helper ${DESTDIR}${UDEV_HELPER_DIR}
 
 clean:
 	rm -f brightnessctl
 
-.PHONY: all install clean
+.PHONY: all install install_udev_rules install_udev_helper clean

--- a/bright-helper
+++ b/bright-helper
@@ -1,0 +1,18 @@
+#!/bin/sh -eu
+die() {
+    echo "$@"
+    exit 1
+}
+
+[ $# -eq 3 ] || die "Usage: $0 group mode file"
+GROUP="$1"
+MODE="$2"
+FILE="$3"
+
+[ -e "$FILE" ] || {
+    echo "File '$FILE' does not exist." >&2
+    exit 0
+}
+
+chgrp "$GROUP" "$FILE"
+chmod "$MODE"  "$FILE"


### PR DESCRIPTION
Otherwise, errors are emited when udev executes the rules against such
hardware, like Apple keyboards.  See Debian bug [#970849].

[#970849]: https://bugs.debian.org/970849