### PR TITLE
Brightness: Exponent: fix default value typo →4

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -124,7 +124,7 @@ int main(int argc, char **argv) {
 		fail("Unable to determine current OS. Exiting!\n");
 	if (strcmp(name.sysname, "Linux"))
 		fail("This program only supports Linux.\n");
-	p.exponent = 1;
+	p.exponent = 4;
 	p.min = (struct value){ .val = 0, .v_type = ABSOLUTE, .d_type = DIRECT, .sign = PLUS };
 	while ((c = getopt_long(argc, argv, "lqpmPn::e::srhVc:d:", options, NULL)) >= 0) {
 		switch (c) {


### PR DESCRIPTION
Hi,

The default value specified on the manual is 4. This gives a rather smooth brightness change following our own visual perception (luminance/brightness curve). Litterature shows a value between 3-4.

However, a typo in the code set the default value 1 instead of 4, making the steps appear non linear.

This fixes that

Thanks and have a nice day/year !