### PR TITLE
Use correct includes for bus providers

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -14,8 +14,12 @@
 #include <string.h>
 #include <math.h>
 
-#ifdef ENABLE_LOGIND
-# include <systemd/sd-bus.h>
+#ifdef HAVE_SYSTEMD
+#include <systemd/sd-bus.h>
+#elif HAVE_ELOGIND
+#include <elogind/sd-bus.h>
+#elif HAVE_BASU
+#include <basu/sd-bus.h>
 #endif
 
 static char *path = "/sys/class";

--- a/configure
+++ b/configure
@@ -122,6 +122,14 @@ if [ "$logind" = "enabled" ]; then
 		exit 1
 		;;
 	esac
+	case "$bus_provider" in
+	libsystemd) CPPFLAGS="$CPPFLAGS -DHAVE_SYSTEMD"
+		;;
+	libelogind) CPPFLAGS="$CPPFLAGS -DHAVE_ELOGIND"
+		;;
+	basu) CPPFLAGS="$CPPFLAGS -DHAVE_BASU"
+		;;
+	esac
 	cat >> config.mk <<EOF
 CFLAGS += $(pkg-config --cflags "$bus_provider")
 LDLIBS += $(pkg-config --libs "$bus_provider")


### PR DESCRIPTION
In particular using Basu as the dbus provider is currently broken.

This is how others do it, see:
https://github.com/emersion/mako/blob/master/include/dbus.h
https://git.sr.ht/~kennylevinsen/poweralertd/tree/master/item/dbus.h

Note that this patch DOES NOT WORK. I don't know configure script syntax and couldn't get it working but this is what a solution would look like I think.