### PR TITLE
README: Update link nixos.wiki -> wiki.nixos.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The program is available in:
 * [Ubuntu](https://packages.ubuntu.com/search?suite=all&searchon=names&keywords=brightnessctl) - starting with 18.04 (and derivatives)
 * [openSUSE](https://build.opensuse.org/package/show/utilities/brightnessctl) - available in Tumbleweed, use OBS `utilities/brightnessctl` devel project for Leap < 15.1
 * [Fedora](https://src.fedoraproject.org/rpms/brightnessctl) - available in Fedora 31+
-* [NixOS/nix](https://search.nixos.org/packages?type=packages&query=brightnessctl) - starting with 17.09, please see the [NixOS Wiki page](https://nixos.wiki/wiki/Backlight#brightnessctl) for the "best-practice" configuration file based installation
+* [NixOS/nix](https://search.nixos.org/packages?type=packages&query=brightnessctl) - starting with 17.09, please see the [NixOS Wiki page](https://wiki.nixos.org/wiki/Backlight#brightnessctl) for the "best-practice" configuration file based installation
 
 One can build and install the program using `./configure && make install`. Consult `./configure --help` for relevant build-time options.
 


### PR DESCRIPTION
The Wiki at `nixos.wiki` is unofficial, and was forked into `wiki.nixos.org`, which is aimed at becoming the official wiki. I think links should be updated to the new wiki.

References: [History of NixOS Wikis](https://wiki.nixos.org/wiki/NixOS_Wiki:History), [Issue Establishing ẁiki.nixos.org`](https://github.com/NixOS/foundation/issues/113)