### PR TITLE
Set dev->matches to true when the --device option isn't being used

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -241,7 +241,8 @@ int main(int argc, char **argv) {
 	if (!(find_devices(devs, p.device)))
 		fail("Device '%s' not found.\n", p.device);
 	while ((dev = *(devp++)))
-		ret |= process_device(dev);
+		if (dev->matches)
+			ret |= process_device(dev);
 	return ret;
 }
 

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -129,7 +129,6 @@ int main(int argc, char **argv) {
 	struct device *devs[255];
 	struct device **devp = devs;
 	struct device *dev;
-	char *dev_name;
 	int ret = 0;
 	int n, c, phelp = 0;
 	p.exponent = 1;
@@ -220,9 +219,6 @@ int main(int argc, char **argv) {
 		list_devices(devs);
 		return 0;
 	}
-	dev_name = p.device;
-	if (!dev_name)
-		dev_name = devs[0]->id;
 	if (argc == 0)
 		p.operation = INFO;
 	else switch (argv[0][0]) {
@@ -242,11 +238,10 @@ int main(int argc, char **argv) {
 		fail("You need to provide a value to set.\n");
 	if (p.operation == SET && !parse_value(&p.val, argv[0]))
 		fail("Invalid value given\n");
-	if (!(find_devices(devs, dev_name)))
-		fail("Device '%s' not found.\n", dev_name);
+	if (!(find_devices(devs, p.device)))
+		fail("Device '%s' not found.\n", p.device);
 	while ((dev = *(devp++)))
-		if (dev->matches)
-			ret |= process_device(dev);
+		ret |= process_device(dev);
 	return ret;
 }
 
@@ -349,7 +344,9 @@ bool find_devices(struct device **devs, char *name) {
 	struct device *dev;
 	bool found = false;
 	while ((dev = *(devs++)))
-		if (!fnmatch(name, dev->id, 0))
+		if (!name)
+			found = dev->matches = true;
+		else if (!fnmatch(name, dev->id, 0))
 			found = dev->matches = true;
 	return found;
 }


### PR DESCRIPTION
Fixes #107

With current implementation, if `--device` isn't used, then `dev_name` is initialized to the first device found, causing only it to be targeted for any operations.  With this tweak it's possible to use the `class` targeting to access multiple devices.

Behavior before:
```
$ ./brightnessctl -c backlight
Device 'card1-eDP-2-backlight' of class 'backlight':
        Current brightness: 200 (50%)
        Max brightness: 400
```

Fixed behavior:
```
$ ./brightnessctl -c backlight
Device 'card1-eDP-2-backlight' of class 'backlight':
        Current brightness: 200 (50%)
        Max brightness: 400

Device 'intel_backlight' of class 'backlight':
        Current brightness: 200 (50%)
        Max brightness: 400

Device 'asus_screenpad' of class 'backlight':
        Current brightness: 35 (15%)
        Max brightness: 235
```
