### PR TITLE
Bias toward nearest whole percentage

### DIFF
--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -75,7 +75,7 @@ struct device {
 	bool matches;
 };
 
-enum value_type { ABSOLUTE, RELATIVE };
+enum value_type { ABSOLUTE, PERCENT };
 enum delta_type { DIRECT, PLUS, MINUS };
 
 struct value {
@@ -340,10 +340,10 @@ bool parse_value(struct value *val, char *str) {
 		val->d_type = MINUS;
 		break;
 	case '%':
-		val->v_type = RELATIVE;
+		val->v_type = PERCENT;
 		break;
 	}
-	if (val->v_type == RELATIVE) {
+	if (val->v_type == PERCENT) {
 		val->percentage = n;
 	} else {
 		val->val = labs((long) n) % LONG_MAX;
@@ -398,14 +398,14 @@ unsigned int calc_value(struct device *d, struct value *val) {
 	long mod = val->val;
 	if (val->d_type == MINUS)
 		mod *= -1;
-	if (val->v_type == RELATIVE) {
+	if (val->v_type == PERCENT) {
 		mod = percent_to_val(val_to_percent(d->curr_brightness, d, false) + mod, d) - d->curr_brightness;
 		if (val->val != 0 && mod == 0)
 			mod = val->d_type == PLUS ? 1 : -1;
 	}
 	new += mod;
 apply:
-	if (p.min.v_type == RELATIVE) {
+	if (p.min.v_type == PERCENT) {
 		p.min.val = percent_to_val(p.min.percentage, d);
 		p.min.v_type = ABSOLUTE;
 	}

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -76,8 +76,7 @@ struct device {
 };
 
 enum value_type { ABSOLUTE, RELATIVE };
-enum delta_type { DIRECT, DELTA };
-enum sign { PLUS, MINUS };
+enum delta_type { DIRECT, PLUS, MINUS };
 
 struct value {
 	union {
@@ -86,7 +85,6 @@ struct value {
 	};
 	enum value_type v_type;
 	enum delta_type d_type;
-	enum sign sign;
 };
 
 enum operation { INFO, GET, MAX, SET, RESTORE };
@@ -138,7 +136,7 @@ int main(int argc, char **argv) {
 	int ret = 0;
 	int n, c, phelp = 0;
 	p.exponent = 1;
-	p.min = (struct value){ .val = 0, .v_type = ABSOLUTE, .d_type = DIRECT, .sign = PLUS };
+	p.min = (struct value){ .val = 0, .v_type = ABSOLUTE, .d_type = DIRECT };
 	while ((c = getopt_long(argc, argv, "lqpmPn::e::srhVc:d:", options, NULL)) >= 0) {
 		switch (c) {
 		case 'l':
@@ -164,10 +162,10 @@ int main(int argc, char **argv) {
 			break;
 		case 'n':
 			if (optarg) {
-				if (!parse_value(&p.min, optarg) || p.min.sign == MINUS)
+				if (!parse_value(&p.min, optarg) || p.min.d_type == MINUS)
 					fail("Invalid min-value given\n");
 			} else if (NULL != argv[optind] && '-' != argv[optind][0]) {
-				if (!parse_value(&p.min, argv[optind++]) || p.min.sign == MINUS)
+				if (!parse_value(&p.min, argv[optind++]) || p.min.d_type == MINUS)
 					fail("Invalid min-value given\n");
 			} else {
 				p.min.val = 1;
@@ -325,12 +323,10 @@ bool parse_value(struct value *val, char *str) {
 	errno = 0;
 	val->v_type = ABSOLUTE;
 	val->d_type = DIRECT;
-	val->sign = PLUS;
 	if (!str || !*str)
 		return false;
 	if (*str == '+' || *str == '-') {
-		val->sign = *str == '+' ? PLUS : MINUS;
-		val->d_type = DELTA;
+		val->d_type = *str == '+' ? PLUS : MINUS;
 		str++;
 	}
 	n = strtod(str, &buf);
@@ -338,12 +334,10 @@ bool parse_value(struct value *val, char *str) {
 		return false;
 	while ((c = *(buf++))) switch(c) {
 	case '+':
-		val->sign = PLUS;
-		val->d_type = DELTA;
+		val->d_type = PLUS;
 		break;
 	case '-':
-		val->sign = MINUS;
-		val->d_type = DELTA;
+		val->d_type = MINUS;
 		break;
 	case '%':
 		val->v_type = RELATIVE;
@@ -401,14 +395,13 @@ unsigned int calc_value(struct device *d, struct value *val) {
 		new = val->v_type == ABSOLUTE ? val->val : percent_to_val(val->percentage, d);
 		goto apply;
 	}
-	int sign_mod = val->sign == MINUS ? -1 : 1;
-	long mod;
+	long mod = val->val;
+	if (val->d_type == MINUS)
+		mod *= -1;
 	if (val->v_type == RELATIVE) {
-		mod = percent_to_val(val_to_percent(d->curr_brightness, d, false) + val->percentage * sign_mod, d) - d->curr_brightness;
-		if (val->percentage != 0 && mod == 0)
-			mod = val->sign == PLUS ? 1 : -1;
-	} else {
-		mod = val->val * sign_mod;
+		mod = percent_to_val(val_to_percent(d->curr_brightness, d, false) + mod, d) - d->curr_brightness;
+		if (val->val != 0 && mod == 0)
+			mod = val->d_type == PLUS ? 1 : -1;
 	}
 	new += mod;
 apply:


### PR DESCRIPTION
# Summary

Fixes consistency issues for devices with low precision when adding or subtracting percentages.

Fixes #118

# Behavior

## Before

```console
$ ./brightnessctl -m --frac s 50%
amdgpu_bl1,backlight,128,50.2%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,154,60.39%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,180,70.59%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,206,80.78%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,232,90.98%,255
```

## After 

```console
$ ./brightnessctl -m --frac s 50%
amdgpu_bl1,backlight,128,50.2%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,153,60%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,179,70.2%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,204,80%,255
$ ./brightnessctl -m --frac s 10%+
amdgpu_bl1,backlight,230,90.2%,255
```