### PR TITLE
Environment variables support

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,7 @@ Valid values:
   percentage value		Example: 50%
   specific delta		Example: 50- or +10
   percentage delta		Example: 50%- or +10%
+
+Environment variables:
+  BRIGHTNESSCTL_DEVICE			The default device to set.
  ```

--- a/brightnessctl.c
+++ b/brightnessctl.c
@@ -197,6 +197,9 @@ int main(int argc, char **argv) {
 		usage();
 		exit(EXIT_FAILURE);
 	}
+	char *env_path = getenv("BRIGHTNESSCTL_DEVICE");
+	if (env_path != NULL && *env_path)
+		p.device = strdup(env_path);
 	argc -= optind;
 	argv += optind;
 	if (p.device && !strcmp(p.device, "*") && !p.class) {


### PR DESCRIPTION
Support environment variable `BRIGHTNESSCTL_DEVICE` to set device

## Background

I'm using Hyprland with [end-4's dotfiles](https://github.com/end-4/dots-hyprland). My laptop has two brightness control devices: `nvidia_0` and `intel_backlight`, both of which can be managed by brightnessctl. By default, brightnessctl uses `nvidia_0`, but only adjustments to `intel_backlight` actually affect the brightness.